### PR TITLE
Adapt code so it works with both Python2 and Python3.

### DIFF
--- a/periodic/__init__.py
+++ b/periodic/__init__.py
@@ -1,2 +1,2 @@
-import mass
-from table import *
+from . import mass
+from .table import *


### PR DESCRIPTION
The suggested change makes periodic happy with the absolute import restriction in Python 3. It still work in Python2 (tried with 2.7.6). Fixes bug #1.
